### PR TITLE
Account.MonthlyPaymentTotal TODOs

### DIFF
--- a/VirtGabbai/DataCache/Models/Account.cs
+++ b/VirtGabbai/DataCache/Models/Account.cs
@@ -30,11 +30,18 @@ namespace DataCache.Models
         {
             get
             {
-                //TODO help-wanted/first-timers-only make this calculation more accurate.
-                //TODO null check this thing
-                decimal? monthesOwedFor = (decimal?)(DateTime.Today - LastMonthlyPaymentDate)?.TotalDays / 30;
+                decimal monthsOwedFor = 0;
+                if (LastMonthlyPaymentDate != null)
+                {
+                    DateTime firstBillableDate = new DateTime(LastMonthlyPaymentDate.Value.AddDays(1).Ticks);
+                    while (firstBillableDate <= DateTime.Today)
+                    {
+                        monthsOwedFor += decimal.Divide(1, DateTime.DaysInMonth(firstBillableDate.Year, firstBillableDate.Month));
+                        firstBillableDate = firstBillableDate.AddDays(1);
+                    }
+                }
 
-                return !monthesOwedFor.HasValue ? 0 : monthesOwedFor.Value * MonthlyPaymentAmount;
+                return monthsOwedFor * MonthlyPaymentAmount;
             }
         }
         public List<Donation> UnpaidDonations => GetUnpaidDonations();

--- a/VirtGabbai/DataCache/Models/Account.cs
+++ b/VirtGabbai/DataCache/Models/Account.cs
@@ -30,19 +30,20 @@ namespace DataCache.Models
         {
             get
             {
-                decimal monthsOwedFor = 0;
+                int monthsOwedFor = 0;
                 if (LastMonthlyPaymentDate != null)
                 {
-                    DateTime firstBillableDate = new DateTime(LastMonthlyPaymentDate.Value.AddDays(1).Ticks);
-                    while (firstBillableDate <= DateTime.Today)
-                    {
-                        monthsOwedFor += decimal.Divide(1, DateTime.DaysInMonth(firstBillableDate.Year, firstBillableDate.Month));
-                        firstBillableDate = firstBillableDate.AddDays(1);
-                    }
+                    DateTime iterationDate = new DateTime(LastMonthlyPaymentDate.Value.Ticks);
+                    
+                    monthsOwedFor = NumberOfMonthsBetweenTwoDates(iterationDate, DateTime.Today);
                 }
 
                 return monthsOwedFor * MonthlyPaymentAmount;
             }
+        }
+        private int NumberOfMonthsBetweenTwoDates(DateTime startDateTime, DateTime endDateTime)
+        {
+            return ((endDateTime.Year - startDateTime.Year)*12) + (endDateTime.Month - startDateTime.Month);
         }
         public List<Donation> UnpaidDonations => GetUnpaidDonations();
         public List<Donation> PaidDonations => GetPaidDonations();

--- a/VirtGabbai/Unit Tests/DataCache.Tests/AccountTest.cs
+++ b/VirtGabbai/Unit Tests/DataCache.Tests/AccountTest.cs
@@ -193,17 +193,16 @@ namespace DataCache.Tests
         {
             DateTime lastPaymentDateTime = new DateTime(DateTime.Today.Year, DateTime.Today.Month - 1, DateTime.DaysInMonth(DateTime.Today.Year, DateTime.Today.Month - 1));
             Account actual = new Account(1, 50.50M, lastPaymentDateTime, new List<Donation>());
-            decimal expectedPaymentTotal = 50.50M * Decimal.Divide((DateTime.Today - lastPaymentDateTime).Days, DateTime.DaysInMonth(DateTime.Today.Year, DateTime.Today.Month));
-            AssertAreEqualDecimal(expectedPaymentTotal, actual.MonthlyPaymentTotal, 0.0001M);
+            decimal expectedPaymentTotal = 50.50M ;
+            Assert.AreEqual(expectedPaymentTotal, actual.MonthlyPaymentTotal);
         }
 
         [TestMethod()]
-        public void AccountMonthlyPaymentTotal_LastPaymentMadeOnDayInCurrentMonth_Equals()
+        public void AccountMonthlyPaymentTotal_LastPaymentMadeOnDayInCurrentMonth_EqualsZero()
         {
-            DateTime lastPaymentDateTime = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 25);
+            DateTime lastPaymentDateTime = new DateTime(DateTime.Today.Year, DateTime.Today.Month, DateTime.Today.Day);
             Account actual = new Account(1, 50.50M, lastPaymentDateTime, new List<Donation>());
-            decimal expectedPaymentTotal = 50.50M * Decimal.Divide((decimal) (DateTime.Today - lastPaymentDateTime).TotalDays, DateTime.DaysInMonth(DateTime.Today.Year, DateTime.Today.Month));
-            AssertAreEqualDecimal(expectedPaymentTotal, actual.MonthlyPaymentTotal, delta: 0.0001M);
+            Assert.AreEqual(0, actual.MonthlyPaymentTotal);
         }
 
         [TestMethod()]
@@ -218,20 +217,8 @@ namespace DataCache.Tests
         {
             DateTime lastPaymentDateTime = new DateTime(DateTime.Today.Year, DateTime.Today.AddMonths(-5).Month, 25);
             Account actual = new Account(1, 50.50M, lastPaymentDateTime, new List<Donation>());
-            decimal expectedPaymentTotal = 0.0M;
-            DateTime firstBillableDate = lastPaymentDateTime.AddDays(1);
-            while (firstBillableDate <= DateTime.Today)
-            {
-                expectedPaymentTotal += decimal.Divide(1, DateTime.DaysInMonth(firstBillableDate.Year, firstBillableDate.Month));
-                firstBillableDate = firstBillableDate.AddDays(1);
-            }
-            expectedPaymentTotal *= 50.50M;
+            decimal expectedPaymentTotal = 50.50M * 5;
             Assert.AreEqual(expectedPaymentTotal, actual.MonthlyPaymentTotal);
-        }
-
-        private static void AssertAreEqualDecimal(decimal expected, decimal actual, decimal delta)
-        {
-            Assert.IsTrue(Math.Abs(expected - actual) < delta);
         }
     }
 }

--- a/VirtGabbai/Unit Tests/DataCache.Tests/AccountTest.cs
+++ b/VirtGabbai/Unit Tests/DataCache.Tests/AccountTest.cs
@@ -180,5 +180,58 @@ namespace DataCache.Tests
 
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod()]
+        public void AccountMonthlyPaymentTotal_SameDateAsPaymentDate_EqualZero()
+        {
+            Account actual = new Account(1, 100.30M, DateTime.Today, new List<Donation>());
+            Assert.AreEqual(0, actual.MonthlyPaymentTotal);
+        }
+
+        [TestMethod()]
+        public void AccountMonthlyPaymentTotal_LastPaymentMadeOnDayOfPreviousMonth_Equals()
+        {
+            DateTime lastPaymentDateTime = new DateTime(DateTime.Today.Year, DateTime.Today.Month - 1, DateTime.DaysInMonth(DateTime.Today.Year, DateTime.Today.Month - 1));
+            Account actual = new Account(1, 50.50M, lastPaymentDateTime, new List<Donation>());
+            decimal expectedPaymentTotal = 50.50M * Decimal.Divide((DateTime.Today - lastPaymentDateTime).Days, DateTime.DaysInMonth(DateTime.Today.Year, DateTime.Today.Month));
+            AssertAreEqualDecimal(expectedPaymentTotal, actual.MonthlyPaymentTotal, 0.0001M);
+        }
+
+        [TestMethod()]
+        public void AccountMonthlyPaymentTotal_LastPaymentMadeOnDayInCurrentMonth_Equals()
+        {
+            DateTime lastPaymentDateTime = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 25);
+            Account actual = new Account(1, 50.50M, lastPaymentDateTime, new List<Donation>());
+            decimal expectedPaymentTotal = 50.50M * Decimal.Divide((decimal) (DateTime.Today - lastPaymentDateTime).TotalDays, DateTime.DaysInMonth(DateTime.Today.Year, DateTime.Today.Month));
+            AssertAreEqualDecimal(expectedPaymentTotal, actual.MonthlyPaymentTotal, delta: 0.0001M);
+        }
+
+        [TestMethod()]
+        public void AccountMonthlyPaymentTotal_LastMonthlyPaymentDateIsNull_EqualsZero()
+        {
+            Account actual = new Account(1, 50.50M, null, new List<Donation>());
+            Assert.AreEqual(0, actual.MonthlyPaymentTotal);
+        }
+
+        [TestMethod()]
+        public void AccountMonthlyPaymentTotal_LastMonthlyPaymentDateIsInAPreviousMonth_EqualsZero()
+        {
+            DateTime lastPaymentDateTime = new DateTime(DateTime.Today.Year, DateTime.Today.AddMonths(-5).Month, 25);
+            Account actual = new Account(1, 50.50M, lastPaymentDateTime, new List<Donation>());
+            decimal expectedPaymentTotal = 0.0M;
+            DateTime firstBillableDate = lastPaymentDateTime.AddDays(1);
+            while (firstBillableDate <= DateTime.Today)
+            {
+                expectedPaymentTotal += decimal.Divide(1, DateTime.DaysInMonth(firstBillableDate.Year, firstBillableDate.Month));
+                firstBillableDate = firstBillableDate.AddDays(1);
+            }
+            expectedPaymentTotal *= 50.50M;
+            Assert.AreEqual(expectedPaymentTotal, actual.MonthlyPaymentTotal);
+        }
+
+        private static void AssertAreEqualDecimal(decimal expected, decimal actual, decimal delta)
+        {
+            Assert.IsTrue(Math.Abs(expected - actual) < delta);
+        }
     }
 }


### PR DESCRIPTION
This is my first contribution to a repo, so apologies if something was done incorrectly.  I added tests as well for the code changes.  After reviewing your TODO lines and the code in the MonthlyPaymenTotal, I made the following assumption(s).  1)That the LastMonthlyPayementDate included the portion for that day, thus if a user tries to calculate a payment for the same LastMonthlyPaymentDate the return is 0.

2) That you wanted the user to pay a percentage of(day/month) * MonthlyPaymentAmount for each day after the LastMonthlyPaymentDate through the Date the Property is accessed. 3)You also wanted a null check, so I did that first but it was unclear what you want it to do if it is null?  I didn't see any standards on code formatting or issues for this, so i will attempt to just make a pull request.  Hope the changes are what you were looking for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-zuber/virtualgabbai/65)
<!-- Reviewable:end -->
